### PR TITLE
Update  syntax for use with python3

### DIFF
--- a/bom_csv_jlcpcb.py
+++ b/bom_csv_jlcpcb.py
@@ -26,7 +26,7 @@ import sys
 
 net = kicad_netlist_reader.netlist(sys.argv[1])
 
-with open(sys.argv[2], 'wb') as f:
+with open(sys.argv[2], 'w') as f:
     out = csv.writer(f)
     out.writerow(['Comment', 'Designator', 'Footprint', 'LCSC Part #'])
 


### PR DESCRIPTION
Establishing Python3 compatibility is simply done by not opening the CSV file in binary mode. I also found this solution to be working by tinkering locally and then found that CaninoDev already has a fix on his fork.